### PR TITLE
feat(cursor): Add Cursor CLI statusline with setup wiring

### DIFF
--- a/cursor/.cursor/statusline.sh
+++ b/cursor/.cursor/statusline.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Cursor CLI statusline (Claude Code layout).
+# Rendered above the prompt; REPLACES the built-in footer, so this also
+# restores the footer's right side (approval mode + vim mode).
+# Killed at timeoutMs, so keep this fast (~200ms budget).
+# Config lives at $XDG_CONFIG_HOME/cursor/cli-config.json when XDG_CONFIG_HOME
+# is set (NOT ~/.cursor/cli-config.json).
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
+ESC=$'\033'
+RESET="${ESC}[0m"
+DIM="${ESC}[2m"
+RED="${ESC}[31m"
+GREEN="${ESC}[32m"
+YELLOW="${ESC}[33m"
+MAGENTA="${ESC}[35m"
+CYAN="${ESC}[36m"
+LIGHT_GRAY="${ESC}[37m"
+
+input=$(cat)
+
+model=$(printf '%s' "$input" | jq -r '.model.display_name // "?"')
+params=$(printf '%s' "$input" | jq -r '.model.param_summary // empty')
+version=$(printf '%s' "$input" | jq -r '.version // empty')
+cwd=$(printf '%s' "$input" | jq -r '.workspace.current_dir // .cwd // "."')
+transcript=$(printf '%s' "$input" | jq -r '.transcript_path // empty')
+used_pct=$(printf '%s' "$input" | jq -r '(.context_window.used_percentage // 0 | floor)')
+ctx_size=$(printf '%s' "$input" | jq -r '(.context_window.context_window_size // 0 | floor)')
+vim_mode=$(printf '%s' "$input" | jq -r '.vim.mode // empty')
+render_width=$(printf '%s' "$input" | jq -r '(.render_width_chars // 0 | floor)')
+# NB: Cursor's payload has no cost/usage-billing fields, so no money segment.
+
+[[ "$used_pct" =~ ^[0-9]+$ ]] || used_pct=0
+[[ "$ctx_size" =~ ^[0-9]+$ ]] || ctx_size=0
+[[ "$render_width" =~ ^[0-9]+$ ]] || render_width=0
+
+# Skip param summary already contained in the display name (e.g. "Kimi K3 Max" + "Max")
+if [[ -n "$params" && "$model" != *"$params"* ]]; then
+	model="${model} ${params}"
+fi
+if [[ "$ctx_size" -gt 0 && "$model" != *context* ]]; then
+	if [[ "$ctx_size" -ge 1000000 ]]; then
+		model="${model} ($((ctx_size / 1000000))M context)"
+	elif [[ "$ctx_size" -ge 1000 ]]; then
+		model="${model} ($((ctx_size / 1000))k context)"
+	fi
+fi
+
+if [[ "$used_pct" -ge 75 ]]; then
+	CONTEXT_COLOR="$RED"
+elif [[ "$used_pct" -ge 50 ]]; then
+	CONTEXT_COLOR="$YELLOW"
+else
+	CONTEXT_COLOR="$CYAN"
+fi
+
+# Git: branch + dirty dot + diff stats vs HEAD (~30ms here; head -1 SIGPIPE-caps status)
+git_info=""
+added=0
+removed=0
+if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+	branch=$(git -C "$cwd" --no-optional-locks symbolic-ref --short HEAD 2>/dev/null)
+	[[ -n "$branch" ]] || branch=$(git -C "$cwd" --no-optional-locks rev-parse --short HEAD 2>/dev/null)
+	if [[ -n "$branch" ]]; then
+		git_info=" ${branch}"
+		if git -C "$cwd" --no-optional-locks status --porcelain 2>/dev/null | head -1 | grep -q .; then
+			git_info="${git_info} ●"
+		fi
+	fi
+	stats=$(git -C "$cwd" --no-optional-locks diff --numstat HEAD 2>/dev/null |
+		awk '{a+=$1; d+=$2} END {printf "%d %d", a, d}')
+	[[ "$stats" =~ ^[0-9]+\ [0-9]+$ ]] && read -r added removed <<<"$stats"
+fi
+
+last_prompt=""
+if [[ -n "$transcript" && -f "$transcript" ]]; then
+	last_prompt=$(jq -r '
+		select(.role == "user")
+		| .message.content
+		| if type == "array" then
+			[.[] | select(.type == "text") | .text] | join(" ")
+		  elif type == "string" then .
+		  else empty end
+		| select(length > 0)
+		| (capture("(?s)<user_query>\\s*(?<q>.*?)\\s*</user_query>") | .q) // .
+		| gsub("\n"; " ")
+		| gsub("\\s+"; " ")
+	' "$transcript" 2>/dev/null | tail -n 1 | cut -c1-80)
+	[[ ${#last_prompt} -eq 80 ]] && last_prompt="${last_prompt}..."
+fi
+
+# --- line 1, left side ---
+line1=""
+[[ -n "$git_info" ]] && line1="${GREEN}🌿${git_info}${RESET} ${DIM}│${RESET} "
+line1="${line1}${MAGENTA}🤖 ${model}${RESET}"
+line1="${line1} ${DIM}│${RESET} ${CONTEXT_COLOR}🧠 ${used_pct}%${RESET}"
+[[ -n "$version" ]] && line1="${line1} ${DIM}│${RESET} ${LIGHT_GRAY}📦 v${version}${RESET}"
+line1="${line1} ${DIM}│${RESET} 📝 ${GREEN}+${added}${RESET}${DIM}/${RESET}${RED}-${removed}${RESET}"
+
+# --- line 1, right side: approval mode + vim mode (the superseded footer's right) ---
+cfg_dir="${CURSOR_CONFIG_DIR:-}"
+[[ -z "$cfg_dir" && -n "${XDG_CONFIG_HOME:-}" ]] && cfg_dir="${XDG_CONFIG_HOME}/cursor"
+[[ -z "$cfg_dir" ]] && cfg_dir="${HOME}/.cursor"
+approval=$(jq -r '.approvalMode // empty' "${cfg_dir}/cli-config.json" 2>/dev/null)
+case "$approval" in
+auto-review) approval_label="Auto-review" ;;
+allowlist) approval_label="Allowlist" ;;
+unrestricted) approval_label="Unrestricted" ;;
+"") approval_label="" ;;
+*) approval_label="${approval^}" ;;
+esac
+right=""
+[[ -n "$approval_label" ]] && right="$approval_label"
+if [[ -n "$vim_mode" ]]; then
+	if [[ -n "$right" ]]; then
+		right="${right} -- ${vim_mode} --"
+	else
+		right="-- ${vim_mode} --"
+	fi
+fi
+
+if [[ -n "$right" ]]; then
+	padded=""
+	if [[ "$render_width" -gt 0 ]] && command -v python3 >/dev/null 2>&1; then
+		plain=$(printf '%s' "$line1" | sed "s/${ESC}\[[0-9;]*m//g")
+		widths=$(python3 -c '
+import sys, unicodedata
+def w(s): return sum(2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in s)
+print(w(sys.argv[1]), w(sys.argv[2]))' "$plain" "$right" 2>/dev/null)
+		if [[ "$widths" =~ ^([0-9]+)\ ([0-9]+)$ ]]; then
+			pad=$((render_width - BASH_REMATCH[1] - BASH_REMATCH[2]))
+			if [[ "$pad" -gt 1 ]]; then
+				printf -v spaces '%*s' "$pad" ''
+				padded="${spaces}"
+			fi
+		fi
+	fi
+	if [[ -n "$padded" ]]; then
+		line1="${line1}${padded}${LIGHT_GRAY}${right}${RESET}"
+	else
+		line1="${line1}  ${LIGHT_GRAY}${right}${RESET}"
+	fi
+fi
+
+printf '%s' "$line1"
+
+if [[ -n "$last_prompt" ]]; then
+	printf '\n%s💬 %s%s' "$LIGHT_GRAY" "$last_prompt" "$RESET"
+fi
+printf '\n'
+exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -30,6 +30,20 @@ brew bundle
 echo "🔗 Creating symlinks..."
 stow --adopt --target=$HOME --restow */
 
+# Cursor CLI status line
+# The CLI resolves its config as $CURSOR_CONFIG_DIR → $XDG_CONFIG_HOME/cursor → ~/.cursor.
+# cli-config.json holds per-machine state (auth, permissions) and the CLI rewrites it,
+# so we merge the statusLine key instead of symlinking the file.
+echo "🎨 Configuring Cursor CLI status line..."
+cursor_cfg_dir="${CURSOR_CONFIG_DIR:-${XDG_CONFIG_HOME:+$XDG_CONFIG_HOME/cursor}}"
+cursor_cfg_dir="${cursor_cfg_dir:-$HOME/.cursor}"
+cursor_cfg="$cursor_cfg_dir/cli-config.json"
+mkdir -p "$cursor_cfg_dir"
+[ -f "$cursor_cfg" ] || echo '{}' >"$cursor_cfg"
+cursor_cfg_tmp=$(mktemp)
+jq '.statusLine = {type: "command", command: "~/.cursor/statusline.sh", padding: 0, timeoutMs: 2000}' \
+  "$cursor_cfg" >"$cursor_cfg_tmp" && mv "$cursor_cfg_tmp" "$cursor_cfg"
+
 # Install runtimes from the global mise config (symlinked by stow above)
 echo "🔧 Installing runtimes via mise..."
 mise install


### PR DESCRIPTION
## Overview

Adds a Cursor CLI statusline that mirrors the Claude Code layout, plus the `setup.sh` wiring that registers it in `cli-config.json`.

## Motivation

Cursor CLI's built-in footer shows less than the Claude Code statusline (no git branch, diff stats, or context usage), and switching between the two tools means relearning where to look. This gives both CLIs the same at-a-glance layout. A custom statusline replaces the built-in footer entirely, so the script also restores the footer's right side (approval mode and vim mode) rather than losing it.

## Changes

### Statusline

- **cursor/.cursor/statusline.sh** - Renders two lines from the JSON payload on stdin: git branch with dirty marker and `+added/-removed` vs `HEAD`, model name with context window size, context usage % (cyan/yellow/red at 50%/75%), CLI version, and the last user prompt from the transcript. Right-aligns approval mode and vim mode using `render_width_chars`, measuring display width with `python3` so emoji don't skew the padding. Uses `--no-optional-locks` and `head -1` on `git status` to stay well under the 2s `timeoutMs`. No cost segment since Cursor's payload has no billing fields.

### Setup

- **setup.sh** - Resolves the config dir the same way the CLI does (`$CURSOR_CONFIG_DIR`, then `$XDG_CONFIG_HOME/cursor`, then `~/.cursor`) and merges a `statusLine` key into `cli-config.json` with `jq`. The file holds per-machine state (auth, permissions) and the CLI rewrites it, so it's merged in place instead of symlinked via stow.

## Breaking Changes

None

## Testing

- [x] `shellcheck` passes on `statusline.sh`, `bash -n` passes on `setup.sh`
- [x] Piped a sample payload into the script and confirmed all segments render (branch + dirty dot, model with `200k context`, context %, version, diff stats, `Allowlist -- NORMAL --` on the right)
- [x] Verified in a live Cursor CLI session
